### PR TITLE
Fix error TS18006: Classes may not have a field named 'constructor'.

### DIFF
--- a/models/SBObject.ts
+++ b/models/SBObject.ts
@@ -12,25 +12,23 @@
 
 import { Function } from './Function';
 import { HttpFile } from '../http/http';
-
 export class SBObject {
-    'constructor'?: Function;
+    'sbConstructor'?: Function; // Rename from 'constructor' to 'sbConstructor'
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+    static readonly attributeTypeMap: Array<{ name: string, baseName: string, type: string, format: string; }> = [
         {
-            "name": "constructor",
+            "name": "sbConstructor",
             "baseName": "constructor",
             "type": "Function",
             "format": ""
-        }    ];
+        }
+    ];
 
     static getAttributeTypeMap() {
         return SBObject.attributeTypeMap;
     }
 
-    public constructor() {
-    }
+    public constructor() { }
 }
-


### PR DESCRIPTION
Fixed the TS18006 error by renaming the constructor field in SBObject.ts to sbConstructor, as TypeScript doesn't allow classes to have a field named constructor. This resolves the issue mentioned in #10.