### PR TITLE
Fix missing dist/ in npm tarball by adding files field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .env.*
 .openapi-generator-ignore
 .npmrc
+.DS_Store

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -29,3 +29,5 @@ tsconfig.json
 README.md
 .env.*
 tests/**
+./scripts
+package.publish.json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [2.1.6] - 2026-04-14
+
+### Fixed
+- Fixed build and publish pipeline
+
+---
+
+## [2.1.5] - 2026-03-13
+
+> ⚠️ This version is not usable via npm due to a missing `dist/` folder in the published package. Please use 2.1.6 or later.
+
+### Added
+- Weekly Do Not Disturb schedules (`dnd_schedules`) support in Push Preferences API
+  - Configure DND time windows per day of the week (`monday`–`sunday`)
+  - Each day supports multiple time windows with `start_hour`, `start_min`, `end_hour`, `end_min`
+
+---
+
 ## [2.0.0] - 2024-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ With this library you can extend your Sendbird integration to include advanced f
 
 # 🔥 Quick start
 
-```javascript  
-import * as sendbird from 'sendbird-platform-sdk-typescript';
+```javascript
+import * as sendbird from '@sendbird/sendbird-platform-sdk-typescript';
 const APP_ID = "YOUR_APP_ID_FROM_DASHBOARD";
 const API_TOKEN = "YOUR_MASTER_API_TOKEN_FROM_DASHBOARD";
 const serverConfig = new sendbird.ServerConfiguration("https://api-{app_id}.sendbird.com", { "app_id": APP_ID })
@@ -40,8 +40,7 @@ userAPI.createUser(API_TOKEN, userData).then((user) => {
 
 # ⚠️ Warnings
 
- 1. This package is not currently in npm. Please see  the Local development section for installation instructions.
- 2. This library is intended for server to server requests. **Do not use in a browser environment**. This SDK uses the Master API Token, which should never be exposed to the outside world like in a webpage or app.
+1. This library is intended for server to server requests. **Do not use in a browser environment**. This SDK uses the Master API Token, which should never be exposed to the outside world like in a webpage or app.
 
 # ⚒️ Prerequisite
 
@@ -54,20 +53,21 @@ You will need [Node.js](https://nodejs.org/en/download/) installed. This has bee
 
 # ⚙️ Installation
 
-🚨 Package not yet in npm 🚨
-```npm install sendbird-platform-sdk-typescript```
+```sh
+npm install @sendbird/sendbird-platform-sdk-typescript
+```
 
 # 🤓 Local Development
 
- 1. Clone the repository
- 2. cd to the `sendbird-platform-sdk-typescript` directory
- 3. run `npm install`
- 4. cd to your project directory
- 5. run `npm install /path/to/sendbird-platform-sdk-typescript --save`
+1. Clone the repository
+2. `cd` to the `sendbird-platform-sdk-typescript` directory
+3. Run `npm install`
+4. Run `npm run build` to create a publish-ready `dist/` directory.
+5. Run `npm pack ./dist` to verify the package contents locally.
 
 
 # 🗃️ Documentation 
-All the documentation for this project lives in the /docs directory of this repo. 
+All the documentation for this project lives in the top-level markdown files in this repo and is copied into `dist/` for packaging.
 
 ##### Helpful links
 

--- a/apis/AnnouncementApi.ts
+++ b/apis/AnnouncementApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/BotApi.ts
+++ b/apis/BotApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/GroupChannelApi.ts
+++ b/apis/GroupChannelApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/MessageApi.ts
+++ b/apis/MessageApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/MetadataApi.ts
+++ b/apis/MetadataApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/ModerationApi.ts
+++ b/apis/ModerationApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/OpenChannelApi.ts
+++ b/apis/OpenChannelApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/StatisticsApi.ts
+++ b/apis/StatisticsApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/apis/UserApi.ts
+++ b/apis/UserApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/auth/auth.ts
+++ b/auth/auth.ts
@@ -1,6 +1,3 @@
-// typings for btoa are incorrect
-//@ts-ignore
-import * as btoa from "btoa";
 import { RequestContext } from "../http/http";
 
 /**

--- a/http/http.ts
+++ b/http/http.ts
@@ -1,9 +1,9 @@
 // TODO: evaluate if we can easily get rid of this library
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
-import * as URLParse from "url-parse";
+import URLParse from "url-parse";
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -49,7 +49,7 @@ export type RequestBody = undefined | string | FormData | URLSearchParams;
 export class RequestContext {
     private headers: { [key: string]: string } = {};
     private body: RequestBody = undefined;
-    private url: URLParse;
+    private url: InstanceType<typeof URLParse>;
     private agent: http.Agent | https.Agent | undefined = undefined;
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/sendbird-platform-sdk-typescript",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "Unlicense",
       "dependencies": {
         "@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "description": "OpenAPI client for sendbird-platform-sdk-typescript",
   "author": "OpenAPI-Generator Contributors",
@@ -22,9 +22,10 @@
   },
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf ./dist && tsc -p tsconfig.json && node scripts/prepare-publish.js",
     "prepare": "npm run build",
-    "prepare-publish": "npm run build && node scripts/prepare-publish.js",
+    "prepare-publish": "node scripts/prepare-publish.js",
+    "pack:publish": "npm pack ./dist",
     "test:integration": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf ./dist && tsc -p tsconfig.json && node scripts/prepare-publish.js",
+    "build": "node scripts/post-generate.js && rm -rf ./dist && tsc -p tsconfig.json && node scripts/prepare-publish.js",
+    "post-generate": "node scripts/post-generate.js",
     "prepare": "npm run build",
     "prepare-publish": "node scripts/prepare-publish.js",
     "pack:publish": "npm pack ./dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
   "version": "2.1.5",
+  "private": true,
   "description": "OpenAPI client for sendbird-platform-sdk-typescript",
   "author": "OpenAPI-Generator Contributors",
   "repository": {
@@ -23,6 +24,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
+    "prepare-publish": "npm run build && node scripts/prepare-publish.js",
     "test:integration": "jest"
   },
   "dependencies": {
@@ -46,9 +48,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/package.publish.json
+++ b/package.publish.json
@@ -1,0 +1,47 @@
+{
+  "name": "@sendbird/sendbird-platform-sdk-typescript",
+  "description": "OpenAPI client for sendbird-platform-sdk-typescript",
+  "license": "Unlicense",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "require": "./index.js",
+      "default": "./index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sendbird/sendbird-platform-sdk-typescript.git"
+  },
+  "keywords": [
+    "fetch",
+    "typescript",
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "dependencies": {
+    "form-data": "^2.5.0",
+    "node-fetch": "^2.6.0",
+    "url-parse": "^1.4.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "apis",
+    "auth",
+    "http",
+    "models",
+    "types",
+    "*.d.ts",
+    "*.js",
+    "*.js.map",
+    "README.md",
+    "CHANGELOG",
+    "LICENSE*",
+    "NOTICE*"
+  ]
+}

--- a/scripts/post-generate.js
+++ b/scripts/post-generate.js
@@ -1,0 +1,60 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..');
+const targetDirs = [
+  path.join(rootDir, 'apis'),
+  path.join(rootDir, 'auth'),
+  path.join(rootDir, 'http'),
+  path.join(rootDir, 'src', 'api', 'generated', 'apis'),
+  path.join(rootDir, 'src', 'api', 'generated', 'auth'),
+  path.join(rootDir, 'src', 'api', 'generated', 'http')
+];
+
+const replacements = [
+  {
+    from: /import \* as FormData from "form-data";/g,
+    to: 'import FormData from "form-data";'
+  },
+  {
+    from: /import \* as URLParse from "url-parse";/g,
+    to: 'import URLParse from "url-parse";'
+  },
+  {
+    from: /\/\/ typings for btoa are incorrect\r?\n\/\/@ts-ignore\r?\nimport \* as btoa from "btoa";\r?\n/g,
+    to: ''
+  },
+  {
+    from: /private url: URLParse;/g,
+    to: 'private url: InstanceType<typeof URLParse>;'
+  }
+];
+
+let changedFiles = 0;
+
+for (const targetDir of targetDirs) {
+  if (!fs.existsSync(targetDir)) {
+    continue;
+  }
+
+  for (const entry of fs.readdirSync(targetDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.ts')) {
+      continue;
+    }
+
+    const filePath = path.join(targetDir, entry.name);
+    const original = fs.readFileSync(filePath, 'utf8');
+    let updated = original;
+
+    for (const replacement of replacements) {
+      updated = updated.replace(replacement.from, replacement.to);
+    }
+
+    if (updated !== original) {
+      fs.writeFileSync(filePath, updated);
+      changedFiles += 1;
+    }
+  }
+}
+
+console.log(`Post-processed generated files: ${changedFiles}`);

--- a/scripts/prepare-publish.js
+++ b/scripts/prepare-publish.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkg = require('../package.json');
+
+const publishPkg = {
+  name: pkg.name,
+  version: pkg.version,
+  description: pkg.description,
+  author: pkg.author,
+  license: pkg.license,
+  main: "./index.js",
+  typings: "./index.d.ts",
+  exports: { ".": "./index.js" },
+  type: pkg.type,
+  repository: pkg.repository,
+  keywords: pkg.keywords,
+  dependencies: pkg.dependencies,
+  publishConfig: pkg.publishConfig
+};
+
+fs.writeFileSync(
+  path.join(__dirname, '../dist/package.json'),
+  JSON.stringify(publishPkg, null, 2) + '\n'
+);
+
+console.log('Created dist/package.json for publishing');

--- a/scripts/prepare-publish.js
+++ b/scripts/prepare-publish.js
@@ -1,27 +1,38 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
+const rootDir = path.resolve(__dirname, '..');
+const publishDir = path.join(rootDir, 'dist');
 const pkg = require('../package.json');
+const publishPkg = JSON.parse(
+  fs.readFileSync(path.join(rootDir, 'package.publish.json'), 'utf8')
+);
 
-const publishPkg = {
-  name: pkg.name,
-  version: pkg.version,
-  description: pkg.description,
-  author: pkg.author,
-  license: pkg.license,
-  main: "./index.js",
-  typings: "./index.d.ts",
-  exports: { ".": "./index.js" },
-  type: pkg.type,
-  repository: pkg.repository,
-  keywords: pkg.keywords,
-  dependencies: pkg.dependencies,
-  publishConfig: pkg.publishConfig
-};
+if (!fs.existsSync(publishDir)) {
+  throw new Error('dist directory does not exist. Run `npm run build` first.');
+}
+
+publishPkg.version = pkg.version;
+
+for (const fileName of ['README.md', 'CHANGELOG']) {
+  const sourcePath = path.join(rootDir, fileName);
+  if (fs.existsSync(sourcePath)) {
+    fs.copyFileSync(sourcePath, path.join(publishDir, fileName));
+  }
+}
+
+for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+  if (
+    entry.isFile() &&
+    (entry.name.startsWith('LICENSE') || entry.name.startsWith('NOTICE'))
+  ) {
+    fs.copyFileSync(path.join(rootDir, entry.name), path.join(publishDir, entry.name));
+  }
+}
 
 fs.writeFileSync(
-  path.join(__dirname, '../dist/package.json'),
+  path.join(publishDir, 'package.json'),
   JSON.stringify(publishPkg, null, 2) + '\n'
 );
 
-console.log('Created dist/package.json for publishing');
+console.log('Created dist package for publishing');

--- a/src/api/generated/apis/AnnouncementApi.ts
+++ b/src/api/generated/apis/AnnouncementApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/BotApi.ts
+++ b/src/api/generated/apis/BotApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/GroupChannelApi.ts
+++ b/src/api/generated/apis/GroupChannelApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/MessageApi.ts
+++ b/src/api/generated/apis/MessageApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/MetadataApi.ts
+++ b/src/api/generated/apis/MetadataApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/ModerationApi.ts
+++ b/src/api/generated/apis/ModerationApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/OpenChannelApi.ts
+++ b/src/api/generated/apis/OpenChannelApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/StatisticsApi.ts
+++ b/src/api/generated/apis/StatisticsApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/apis/UserApi.ts
+++ b/src/api/generated/apis/UserApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/src/api/generated/auth/auth.ts
+++ b/src/api/generated/auth/auth.ts
@@ -1,6 +1,3 @@
-// typings for btoa are incorrect
-//@ts-ignore
-import * as btoa from "btoa";
 import { RequestContext } from "../http/http";
 
 /**

--- a/src/api/generated/http/http.ts
+++ b/src/api/generated/http/http.ts
@@ -1,9 +1,9 @@
 // TODO: evaluate if we can easily get rid of this library
-import * as FormData from "form-data";
+import FormData from "form-data";
 import { URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
-import * as URLParse from "url-parse";
+import URLParse from "url-parse";
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -49,7 +49,7 @@ export type RequestBody = undefined | string | FormData | URLSearchParams;
 export class RequestContext {
     private headers: { [key: string]: string } = {};
     private body: RequestBody = undefined;
-    private url: URLParse;
+    private url: InstanceType<typeof URLParse>;
     private agent: http.Agent | https.Agent | undefined = undefined;
 
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,13 +17,14 @@
     "outDir": "./dist",
     "noLib": false,
     "lib": [ "ES2015" ],
-    "types": ["jest"]
+    "types": ["node", "jest"]
   },
   "exclude": [
     "dist",
-    "node_modules"
-  ],
-  "filesGlob": [
-    "./**/*.ts",
+    "node_modules",
+    "src",
+    "tests",
+    "jest.config.ts",
+    "jest.setup.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,10 @@
     "strict": true,
     /* Basic Options */
     "target": "ES2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
+    "esModuleInterop": true,
 
     /* Additional Checks */
      "noUnusedLocals": false,                /* Report errors on unused locals. */ // TODO: reenable (unused imports!)


### PR DESCRIPTION
Add "files": ["dist"] to package.json so that the compiled dist/ folder is included in the npm publish tarball. Without this, npm falls back to .gitignore which excludes dist/, causing module resolution failures.

Resolves: CLNP-8431