### PR TITLE
Add npm links metadata

### DIFF
--- a/src/api/generated/package.json
+++ b/src/api/generated/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/sendbird/sendbird-platform-sdk-typescript.git"
   },
+  "homepage": "https://github.com/sendbird/sendbird-platform-sdk-typescript#readme",
+  "bugs": {
+    "url": "https://github.com/sendbird/sendbird-platform-sdk-typescript/issues"
+  },
   "keywords": [
     "fetch",
     "typescript",


### PR DESCRIPTION
## Summary

- add npm `homepage` metadata for `sendbird-platform-sdk-typescript`
- add npm `bugs.url` metadata pointing to the repository issue tracker

This is metadata-only. Runtime code, generated API files, dependencies, package version, exports, and build output are unchanged.

## Validation

```sh
node metadata assertion for src/api/generated/package.json
git diff --check
(cd src/api/generated && npm pack --dry-run --ignore-scripts --json)
```

The dry-run package includes `package.json`.
