### PR TITLE
Add phone_number to createAUser request; bump to 2.1.7 (CLNP-8697)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [2.1.7] - 2026-07-01
+## [2.1.7] - 2026-07-02
 
 ### Added
 - `phone_number` support in the `createAUser` (`POST /v3/users`) request — a user's phone number (with country code) can now be set at creation. Values are normalized to E.164 by the server (e.g. `+82010…` is stored as `+8210…`).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [2.1.7] - 2026-07-01
+
+### Added
+- `phone_number` support in the `createAUser` (`POST /v3/users`) request — a user's phone number (with country code) can now be set at creation. Values are normalized to E.164 by the server (e.g. `+82010…` is stored as `+8210…`).
+
+---
+
 ## [2.1.6] - 2026-04-14
 
 ### Fixed

--- a/UserApi.md
+++ b/UserApi.md
@@ -188,6 +188,7 @@ let body:Sendbird.UserApiCreateAUserRequest = {
     issueAccessToken: true,
     metadata: {},
     nickname: "nickname_example",
+    phoneNumber: "+82010XXXXXXXX",
     profileFile: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
     profileUrl: "profileUrl_example",
     userId: "userId_example",

--- a/models/CreateAUserRequest.ts
+++ b/models/CreateAUserRequest.ts
@@ -18,6 +18,10 @@ export class CreateAUserRequest {
     'metadata'?: any;
     'nickname': string;
     /**
+    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX.
+    */
+    'phoneNumber'?: string;
+    /**
     * Specifies the file of the user's profile image. An acceptable image is limited to a JPG, JPEG, or PNG file of up to 5 MB. When passing a file, you should send a multipart request. If the profile_file property is specified, the profile_url property is not required.
     */
     'profileFile'?: HttpFile;
@@ -48,6 +52,12 @@ export class CreateAUserRequest {
         {
             "name": "nickname",
             "baseName": "nickname",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "phoneNumber",
+            "baseName": "phone_number",
             "type": "string",
             "format": ""
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/sendbird-platform-sdk-typescript",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "Unlicense",
       "dependencies": {
         "@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "description": "OpenAPI client for sendbird-platform-sdk-typescript",
   "author": "OpenAPI-Generator Contributors",

--- a/src/api/generated/models/CreateAUserRequest.ts
+++ b/src/api/generated/models/CreateAUserRequest.ts
@@ -18,6 +18,10 @@ export class CreateAUserRequest {
     'metadata'?: any;
     'nickname': string;
     /**
+    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX.
+    */
+    'phoneNumber'?: string;
+    /**
     * Specifies the file of the user's profile image. An acceptable image is limited to a JPG, JPEG, or PNG file of up to 5 MB. When passing a file, you should send a multipart request. If the profile_file property is specified, the profile_url property is not required.
     */
     'profileFile'?: HttpFile;
@@ -48,6 +52,12 @@ export class CreateAUserRequest {
         {
             "name": "nickname",
             "baseName": "nickname",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "phoneNumber",
+            "baseName": "phone_number",
             "type": "string",
             "format": ""
         },

--- a/tests/integration/user.test.ts
+++ b/tests/integration/user.test.ts
@@ -720,6 +720,42 @@ describe("User API", () => {
     expect(deleteAUserResponse).toBeDefined();
   });
 
+  it("call createAUser with phone_number and verify it is set", async () => {
+    const USER_ID = "test-create-user-phone-number";
+    const USER_NICKNAME = "test-create-user-phone-number-nickname";
+    // Sendbird normalizes phone numbers to E.164, dropping the national trunk
+    // "0" (e.g. +82010... is stored as +8210...), so we send an already-
+    // normalized number to keep the exact-match assertion valid. A unique
+    // suffix is generated per run because phone_number has a global uniqueness
+    // constraint that persists even after the user is deleted.
+    const USER_PHONE_NUMBER = `+8210${String(Date.now()).slice(-8)}`;
+
+    try {
+      await userApi.deleteAUser({ userId: USER_ID, apiToken: API_TOKEN });
+    } catch {}
+
+    const createAUserRequest: CreateAUserRequest = {
+      userId: USER_ID,
+      nickname: USER_NICKNAME,
+      profileUrl: "",
+      phoneNumber: USER_PHONE_NUMBER,
+    };
+    const createAUserResponse = await userApi.createAUser({
+      apiToken: API_TOKEN,
+      createAUserRequest,
+    });
+
+    await userApi.deleteAUser({ userId: USER_ID, apiToken: API_TOKEN });
+
+    // The createAUser response echoes the (normalized) phone_number, confirming
+    // the server accepted and processed it. Note: viewAUser/updateAUser
+    // responses omit phone_number, so we assert on the create response.
+    expect(createAUserResponse.userId).toBe(USER_ID);
+    expect(createAUserResponse).toHaveProperty("phoneNumber");
+    expect(createAUserResponse.phoneNumber).toBe(USER_PHONE_NUMBER);
+    expect(typeof createAUserResponse.phoneNumber).toBe("string");
+  });
+
   it("call createUserMetadata", async () => {
     const TEST_METADATA_KEY = "create_metadata_key";
     const TEST_METADATA_VALUE = "test_value";


### PR DESCRIPTION
Regenerate CreateAUserRequest with optional phoneNumber (wire: phone_number) from the updated spec, sync the src/api/generated mirror and UserApi.md example, add an integration test, bump package-lock.json to 2.1.7, and add a CHANGELOG entry for 2.1.7.