### PR TITLE
Add SBM-only / PII warning for phone_number (CHANGELOG + model doc)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `phone_number` support in the `createAUser` (`POST /v3/users`) request — a user's phone number (with country code) can now be set at creation. Values are normalized to E.164 by the server (e.g. `+82010…` is stored as `+8210…`).
 
+> ⚠️ `phone_number` is intended for **Sendbird Business Messaging (SBM)** use (e.g. Alim Talk / SMS). For general **Chat**, setting `phone_number` is **not recommended** — the Platform API advises against storing PII such as phone numbers on users for data-security and privacy reasons.
+
 ---
 
 ## [2.1.6] - 2026-04-14

--- a/models/CreateAUserRequest.ts
+++ b/models/CreateAUserRequest.ts
@@ -18,7 +18,7 @@ export class CreateAUserRequest {
     'metadata'?: any;
     'nickname': string;
     /**
-    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX.
+    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX. Intended for Sendbird Business Messaging (SBM) use (e.g. Alim Talk / SMS). Not recommended for general Chat, as the Platform API advises against storing PII such as phone numbers for data-security and privacy reasons.
     */
     'phoneNumber'?: string;
     /**

--- a/src/api/generated/models/CreateAUserRequest.ts
+++ b/src/api/generated/models/CreateAUserRequest.ts
@@ -18,7 +18,7 @@ export class CreateAUserRequest {
     'metadata'?: any;
     'nickname': string;
     /**
-    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX.
+    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX. Intended for Sendbird Business Messaging (SBM) use (e.g. Alim Talk / SMS). Not recommended for general Chat, as the Platform API advises against storing PII such as phone numbers for data-security and privacy reasons.
     */
     'phoneNumber'?: string;
     /**


### PR DESCRIPTION
Add a CHANGELOG note and extend the phoneNumber field doc to flag SBM-only intent and advise against PII on general Chat users, per the Platform API guidance.