### PR TITLE
[CLNP-8725] Add phone_number to updateAUser request; bump to 2.1.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [2.1.8] - 2026-07-10
+
+### Added
+- `phone_number` support in the `updateAUser` (`PUT /v3/users/{user_id}`) request — a user's phone number can now be updated on an existing user. Values are normalized to E.164 by the server (e.g. `+82010…` is stored as `+8210…`). The `updateAUser` and `viewAUser` responses omit `phone_number`; use `listUsers` (which returns it per user) to read the stored value back.
+
+> ⚠️ `phone_number` is intended for **Sendbird Business Messaging (SBM)** use (e.g. Alim Talk / SMS). For general **Chat**, setting `phone_number` is **not recommended** — the Platform API advises against storing PII such as phone numbers on users for data-security and privacy reasons.
+
+---
+
 ## [2.1.7] - 2026-07-02
 
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [2.1.8] - 2026-07-10
+## [2.1.8] - 2026-07-14
 
 ### Added
 - `phone_number` support in the `updateAUser` (`PUT /v3/users/{user_id}`) request — a user's phone number can now be updated on an existing user. Values are normalized to E.164 by the server (e.g. `+82010…` is stored as `+8210…`). The `updateAUser` and `viewAUser` responses omit `phone_number`; use `listUsers` (which returns it per user) to read the stored value back.

--- a/UserApi.md
+++ b/UserApi.md
@@ -1126,6 +1126,7 @@ let body:Sendbird.UserApiUpdateAUserRequest = {
     preferredLanguages: [
       "preferredLanguages_example",
     ],
+    phoneNumber: "+82010XXXXXXXX",
     profileFile: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
     profileUrl: "profileUrl_example",
   },

--- a/models/UpdateAUserRequest.ts
+++ b/models/UpdateAUserRequest.ts
@@ -20,6 +20,10 @@ export class UpdateAUserRequest {
     'leaveAllWhenDeactivated'?: boolean;
     'nickname'?: string;
     'preferredLanguages'?: Array<string>;
+    /**
+    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX. Intended for Sendbird Business Messaging (SBM) use (e.g. Alim Talk / SMS). Not recommended for general Chat, as the Platform API advises against storing PII such as phone numbers for data-security and privacy reasons.
+    */
+    'phoneNumber'?: string;
     'profileFile'?: HttpFile;
     'profileUrl'?: string;
 
@@ -66,6 +70,12 @@ export class UpdateAUserRequest {
             "name": "preferredLanguages",
             "baseName": "preferred_languages",
             "type": "Array<string>",
+            "format": ""
+        },
+        {
+            "name": "phoneNumber",
+            "baseName": "phone_number",
+            "type": "string",
             "format": ""
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/sendbird-platform-sdk-typescript",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "Unlicense",
       "dependencies": {
         "@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/sendbird-platform-sdk-typescript",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "private": true,
   "description": "OpenAPI client for sendbird-platform-sdk-typescript",
   "author": "OpenAPI-Generator Contributors",

--- a/src/api/generated/models/UpdateAUserRequest.ts
+++ b/src/api/generated/models/UpdateAUserRequest.ts
@@ -20,6 +20,10 @@ export class UpdateAUserRequest {
     'leaveAllWhenDeactivated'?: boolean;
     'nickname'?: string;
     'preferredLanguages'?: Array<string>;
+    /**
+    * Specifies the user's phone number with the country code. An example would be: +82010XXXXXXXX. Intended for Sendbird Business Messaging (SBM) use (e.g. Alim Talk / SMS). Not recommended for general Chat, as the Platform API advises against storing PII such as phone numbers for data-security and privacy reasons.
+    */
+    'phoneNumber'?: string;
     'profileFile'?: HttpFile;
     'profileUrl'?: string;
 
@@ -66,6 +70,12 @@ export class UpdateAUserRequest {
             "name": "preferredLanguages",
             "baseName": "preferred_languages",
             "type": "Array<string>",
+            "format": ""
+        },
+        {
+            "name": "phoneNumber",
+            "baseName": "phone_number",
+            "type": "string",
             "format": ""
         },
         {

--- a/tests/integration/user.test.ts
+++ b/tests/integration/user.test.ts
@@ -756,6 +756,76 @@ describe("User API", () => {
     expect(typeof createAUserResponse.phoneNumber).toBe("string");
   });
 
+  it("call updateAUser with phone_number and verify it via listUsers", async () => {
+    const USER_ID = "test-update-user-phone-number";
+    const USER_NICKNAME = "test-update-user-phone-number-nickname";
+    // Send already-E.164-normalized numbers (Sendbird drops the national trunk
+    // "0", e.g. +82010... is stored as +8210...) so exact-match assertions hold.
+    // Use random 8-digit suffixes so numbers don't repeat across runs: a
+    // timestamp suffix (Date.now() % 1e8) would cycle every ~27.8h and could
+    // reuse a prior run's number. Assertions look up by user_id (not by phone),
+    // so this stays correct even if phone-number uniqueness is enabled.
+    const rand8 = () => String(Math.floor(10000000 + Math.random() * 89999999));
+    const INITIAL_PHONE_NUMBER = `+8210${rand8()}`;
+    let UPDATED_PHONE_NUMBER = `+8210${rand8()}`;
+    while (UPDATED_PHONE_NUMBER === INITIAL_PHONE_NUMBER) {
+      UPDATED_PHONE_NUMBER = `+8210${rand8()}`;
+    }
+
+    try {
+      await userApi.deleteAUser({ userId: USER_ID, apiToken: API_TOKEN });
+    } catch {}
+
+    try {
+      // Create the user with an initial phone number.
+      await userApi.createAUser({
+        apiToken: API_TOKEN,
+        createAUserRequest: {
+          userId: USER_ID,
+          nickname: USER_NICKNAME,
+          profileUrl: "",
+          phoneNumber: INITIAL_PHONE_NUMBER,
+        },
+      });
+
+      // Update the phone number via updateAUser.
+      const updateAUserResponse = await userApi.updateAUser({
+        userId: USER_ID,
+        apiToken: API_TOKEN,
+        updateAUserRequest: {
+          phoneNumber: UPDATED_PHONE_NUMBER,
+        },
+      });
+
+      // Read the phone number back. The updateAUser and viewAUser responses omit
+      // phone_number entirely; only createAUser echoes it and listUsers includes
+      // it per user object, so listUsers (filtered by user_ids) is the way to
+      // verify that updateAUser actually persisted the new value.
+      const listUsersResponse = await userApi.listUsers({
+        apiToken: API_TOKEN,
+        userIds: USER_ID,
+        limit: 10,
+      });
+
+      // The updateAUser response itself does not surface phone_number.
+      expect(updateAUserResponse.userId).toBe(USER_ID);
+      expect(updateAUserResponse).not.toHaveProperty("phoneNumber");
+
+      // listUsers reflects the updated (normalized) phone number.
+      const updatedUser = listUsersResponse.users?.find(
+        (user) => user.userId === USER_ID
+      );
+      expect(updatedUser).toBeDefined();
+      expect(updatedUser).toHaveProperty("phoneNumber");
+      expect(updatedUser?.phoneNumber).toBe(UPDATED_PHONE_NUMBER);
+      expect(typeof updatedUser?.phoneNumber).toBe("string");
+    } finally {
+      await userApi
+        .deleteAUser({ userId: USER_ID, apiToken: API_TOKEN })
+        .catch(() => {});
+    }
+  });
+
   it("call createUserMetadata", async () => {
     const TEST_METADATA_KEY = "create_metadata_key";
     const TEST_METADATA_VALUE = "test_value";


### PR DESCRIPTION
Regenerate UpdateAUserRequest with optional phoneNumber (wire: phone_number) from the updated spec, sync the src/api/generated mirror and the UserApi.md example, add an integration test, bump package-lock.json to 2.1.8, and add a CHANGELOG entry for 2.1.8.

Follow-up to CLNP-8697 (createAUser phone_number). The updateAUser and viewAUser responses omit phone_number; listUsers returns it per user, so the test verifies persistence via listUsers.