### PR TITLE
[CLNP-8795][fix]: bump js-yaml to 3.15.1 and brace-expansion to 5.0.9 to clear DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,9 +1401,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5437,9 +5437,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "requires": {
         "balanced-match": "^4.0.2"
@@ -6742,7 +6742,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^5.0.8"
+        "brace-expansion": "^5.0.9"
       }
     },
     "minimist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3131,9 +3131,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4787,7 +4787,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.1",
         "resolve-from": "^5.0.0"
       }
     },
@@ -6595,9 +6595,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "js-yaml": "^3.15.1"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.8",
+    "js-yaml": "^3.15.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Patches two High-severity **dev-only** supply-chain DoS advisories flagged by Semgrep Supply Chain against the TypeScript SDK. Both are transitive dependencies of the jest test/coverage toolchain and are **not shipped** in the published package (`npm audit --omit=dev` was already clean); this restores a fully clean `npm audit`.

| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| `js-yaml` | 3.15.0 | **3.15.1** | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) / CVE-2026-59870 (SECURE-4441) |
| `brace-expansion` | 5.0.8 | **5.0.9** | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) |

## js-yaml — SECURE-4441

`js-yaml` 3.15.0 is vulnerable to quadratic CPU consumption when resolving large `!!omap` sequences (a linear duplicate-key scan inside the per-element loop, O(N²)), which can block the event loop (DoS). The advisory covers both the 3.x and 4.x lines.

- **Dependency path:** `jest → @istanbuljs/load-nyc-config@1.1.0 → js-yaml@^3.13.1` — a single, dev-only instance, used only to parse `.nycrc.yml` coverage config.
- Follow-up to SECURE-4145, whose fix had moved js-yaml to 3.15.0; that same 3.15.0 is now flagged by this new, distinct advisory.
- The caret range already permits 3.15.1, so an `overrides` pin (`^3.15.1`, kept on the 3.x line to preserve the `load`/`safeLoad` API that load-nyc-config relies on) resolves it and prevents lockfile regression.

## brace-expansion (bundled)

The existing `^5.0.8` override (added for CVE-2026-14257) now itself falls in the vulnerable range `4.0.0 - 5.0.8` under GHSA-rgw5-rvv9-x895. Bumped the override to `^5.0.9` (patched, dev-only, via `jest → … → minimatch`) to keep `npm audit` fully clean.

## Reachability

Conditionally Reachable per Semgrep; in practice **not reachable**. Both packages are dev-only, are not included in the published `dist/` tarball, and there is no `.nycrc.yml` in the repo to trigger the js-yaml parse path. Patched per supply-chain policy.

## Verification

- `npm audit` → **found 0 vulnerabilities** (both full and `--omit=dev`)
- `npm ls` → `js-yaml@3.15.1 overridden`, `brace-expansion@5.0.9 overridden` (single instances)
- `tsc -p tsconfig.json --noEmit` passes; jest boots (integration suites)
- Only `package.json` + `package-lock.json` change; `overrides` are not shipped, and `.openapi-generator-ignore` protects both files from SDK regeneration.

## Tickets

- SECURE-4441 (js-yaml) — https://sendbird.atlassian.net/browse/SECURE-4441
- CLNP-8795
- brace-expansion advisory GHSA-rgw5-rvv9-x895 — bundled here; no dedicated ticket yet
